### PR TITLE
Login flow fixed from signup -> verify -> login to signup -> verify -…

### DIFF
--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -6,7 +6,7 @@ import { Card } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Eye, EyeOff } from "lucide-react";
-import { signUpEmailPassword, verifyEmail, resendVerificationCode } from "@/lib/better-auth-client";
+import { signUpEmailPassword, verifyEmail, resendVerificationCode, signInEmailPassword } from "@/lib/better-auth-client";
 import React from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -53,10 +53,12 @@ export default function Page() {
     
     try {
       await verifyEmail({ email, code: verificationCode });
-      setSuccessMessage("Email verified successfully! Redirecting...");
+
+      await signInEmailPassword({email, password})
+      setSuccessMessage("Email verified successfully! Logging you in...");
       setTimeout(() => {
-        router.replace("/sign-in");
-      }, 2000);
+        router.replace("/");
+      }, 1500);
     } catch (err: any) {
       setError(err?.message || "Failed to verify email");
     } finally {


### PR DESCRIPTION
This pull request updates the sign-up flow to automatically log in users after they verify their email, streamlining the user experience. Instead of redirecting users to the sign-in page after verification, the system now signs them in and redirects them to the home page.

**Sign-up flow improvements:**

* Added `signInEmailPassword` to the imports from `@/lib/better-auth-client`, enabling automatic sign-in after email verification.
* After successful email verification, the code now calls `signInEmailPassword`, updates the success message, and redirects the user to the home page (`/`) instead of the sign-in page (`/sign-in`). The redirect delay was also shortened from 2000ms to 1500ms.