### PR TITLE
feat: expand verdict categories for more nuanced fact-checking

### DIFF
--- a/app/api/crowdsource/news/route.ts
+++ b/app/api/crowdsource/news/route.ts
@@ -21,7 +21,7 @@ const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
  * Generate fake analysis for a news article
  */
 function generateFakeAnalysis() {
-  const verdicts = ["Verified", "Misleading", "Unverifiable", "False"] as const;
+  const verdicts = ["Verified", "Misleading", "Unverifiable", "False", "Partially True", "Outdated", "Exaggerated", "Opinion", "Rumor", "Conspiracy", "Debunked", "Satire"] as const;
   const verdict = verdicts[Math.floor(Math.random() * verdicts.length)];
   const confidence = Math.floor(Math.random() * 30) + 70; // 70-100%
 
@@ -34,6 +34,22 @@ function generateFakeAnalysis() {
       "The claims in this article cannot be verified with available information and credible sources.",
     False:
       "Our analysis has identified multiple factual errors and unsubstantiated claims in this article.",
+    "Partially True":
+      "This article contains both accurate and inaccurate elements. Some claims are supported by evidence while others are not.",
+    Outdated:
+      "This information was accurate at one time but has been superseded by newer evidence or developments.",
+    Exaggerated:
+      "While based on some truth, this article overstates or sensationalizes the facts beyond what evidence supports.",
+    Opinion:
+      "This article expresses subjective views or personal beliefs rather than factual claims that can be verified.",
+    Rumor:
+      "This appears to be unverified information circulating without credible sources or confirmation.",
+    Conspiracy:
+      "This article involves claims about secret plots or hidden agendas without credible evidence to support them.",
+    Debunked:
+      "This claim has been thoroughly disproven by multiple credible sources and scientific evidence.",
+    Satire:
+      "This article appears to be satirical, parody, or comedy in nature and should not be interpreted as factual information.",
   };
 
   const keyPointsOptions = [
@@ -56,6 +72,46 @@ function generateFakeAnalysis() {
       "Multiple factual errors identified",
       "Sources cited are not credible",
       "Information contradicts verified data",
+    ],
+    [
+      "Some claims are accurate while others are false",
+      "Mixed evidence supports different parts of the story",
+      "Requires careful distinction between true and false elements",
+    ],
+    [
+      "Information was accurate when originally published",
+      "New developments have changed the situation",
+      "Readers should seek updated information",
+    ],
+    [
+      "Core facts are true but overstated",
+      "Statistics are inflated beyond actual data",
+      "Sensational language exaggerates the significance",
+    ],
+    [
+      "Content expresses personal views",
+      "Not intended as factual reporting",
+      "Subjective interpretation of events",
+    ],
+    [
+      "Unverified information circulating",
+      "No credible sources confirm the claims",
+      "Appears to be speculation or hearsay",
+    ],
+    [
+      "Claims involve secretive plots",
+      "No credible evidence supports conspiracy theories",
+      "Multiple sources have debunked these claims",
+    ],
+    [
+      "Scientific evidence contradicts the claims",
+      "Multiple studies have disproven this theory",
+      "Expert consensus rejects these assertions",
+    ],
+    [
+      "Content is intended as humor or parody",
+      "Not meant to be taken as factual information",
+      "Comedic elements should not be interpreted literally",
     ],
   ];
 

--- a/app/api/transcribe/handlers/base-handler.ts
+++ b/app/api/transcribe/handlers/base-handler.ts
@@ -34,7 +34,7 @@ export interface ExtractedContent {
  * Fact check result interface
  */
 export interface FactCheckResult {
-  verdict: "verified" | "misleading" | "false" | "unverified" | "satire";
+  verdict: "verified" | "misleading" | "false" | "unverified" | "satire" | "partially_true" | "outdated" | "exaggerated" | "opinion" | "rumor" | "conspiracy" | "debunked";
   confidence: number; // 0-100
   explanation: string;
   content: string; // Summary/content of what was fact-checked

--- a/components/analyses-content.tsx
+++ b/components/analyses-content.tsx
@@ -47,6 +47,20 @@ const getStatusIcon = (status: string) => {
       return <AlertCircleIcon className="h-4 w-4 text-gray-500" />;
     case "satire":
       return <span className="text-purple-500 text-sm">🎭</span>;
+    case "partially_true":
+      return <AlertTriangleIcon className="h-4 w-4 text-yellow-600" />;
+    case "outdated":
+      return <AlertCircleIcon className="h-4 w-4 text-gray-600" />;
+    case "exaggerated":
+      return <AlertTriangleIcon className="h-4 w-4 text-orange-600" />;
+    case "opinion":
+      return <AlertCircleIcon className="h-4 w-4 text-blue-500" />;
+    case "rumor":
+      return <AlertCircleIcon className="h-4 w-4 text-gray-400" />;
+    case "conspiracy":
+      return <XCircleIcon className="h-4 w-4 text-red-500" />;
+    case "debunked":
+      return <XCircleIcon className="h-4 w-4 text-red-700" />;
     default:
       return <AlertCircleIcon className="h-4 w-4 text-blue-500" />;
   }
@@ -77,6 +91,38 @@ const getStatusBadge = (status: string) => {
         <Badge className="bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200">
           Satire
         </Badge>
+      );
+    case "partially_true":
+      return (
+        <Badge className="bg-yellow-100 text-yellow-800">Partially True</Badge>
+      );
+    case "outdated":
+      return (
+        <Badge className="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200">
+          Outdated
+        </Badge>
+      );
+    case "exaggerated":
+      return (
+        <Badge className="bg-orange-100 text-orange-800">Exaggerated</Badge>
+      );
+    case "opinion":
+      return (
+        <Badge className="bg-blue-100 text-blue-800">Opinion</Badge>
+      );
+    case "rumor":
+      return (
+        <Badge className="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200">
+          Rumor
+        </Badge>
+      );
+    case "conspiracy":
+      return (
+        <Badge className="bg-red-100 text-red-800">Conspiracy</Badge>
+      );
+    case "debunked":
+      return (
+        <Badge className="bg-red-100 text-red-800">Debunked</Badge>
       );
     default:
       return (

--- a/components/analysis/origin-tracing-diagram/nodes/ClaimNode.tsx
+++ b/components/analysis/origin-tracing-diagram/nodes/ClaimNode.tsx
@@ -16,6 +16,13 @@ export function ClaimNode({ data }: { data: NodeData }) {
       iconColor: 'text-emerald-600',
       badge: 'bg-emerald-100 text-emerald-800 border-emerald-300'
     },
+    partially_true: {
+      bg: 'bg-gradient-to-br from-yellow-50 via-amber-50 to-orange-50',
+      border: 'border-yellow-300',
+      text: 'text-yellow-900',
+      iconColor: 'text-yellow-600',
+      badge: 'bg-yellow-100 text-yellow-800 border-yellow-300'
+    },
     misleading: {
       bg: 'bg-gradient-to-br from-amber-50 via-yellow-50 to-orange-50',
       border: 'border-amber-300',
@@ -44,14 +51,63 @@ export function ClaimNode({ data }: { data: NodeData }) {
       iconColor: 'text-violet-600',
       badge: 'bg-violet-100 text-violet-800 border-violet-300'
     },
+    outdated: {
+      bg: 'bg-gradient-to-br from-gray-50 via-slate-50 to-zinc-50',
+      border: 'border-gray-300',
+      text: 'text-gray-900',
+      iconColor: 'text-gray-600',
+      badge: 'bg-gray-100 text-gray-800 border-gray-300'
+    },
+    exaggerated: {
+      bg: 'bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50',
+      border: 'border-orange-300',
+      text: 'text-orange-900',
+      iconColor: 'text-orange-600',
+      badge: 'bg-orange-100 text-orange-800 border-orange-300'
+    },
+    opinion: {
+      bg: 'bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50',
+      border: 'border-blue-300',
+      text: 'text-blue-900',
+      iconColor: 'text-blue-600',
+      badge: 'bg-blue-100 text-blue-800 border-blue-300'
+    },
+    rumor: {
+      bg: 'bg-gradient-to-br from-gray-50 via-slate-50 to-zinc-50',
+      border: 'border-gray-300',
+      text: 'text-gray-900',
+      iconColor: 'text-gray-600',
+      badge: 'bg-gray-100 text-gray-800 border-gray-300'
+    },
+    conspiracy: {
+      bg: 'bg-gradient-to-br from-red-50 via-rose-50 to-pink-50',
+      border: 'border-red-300',
+      text: 'text-red-900',
+      iconColor: 'text-red-600',
+      badge: 'bg-red-100 text-red-800 border-red-300'
+    },
+    debunked: {
+      bg: 'bg-gradient-to-br from-red-50 via-rose-50 to-pink-50',
+      border: 'border-red-300',
+      text: 'text-red-900',
+      iconColor: 'text-red-600',
+      badge: 'bg-red-100 text-red-800 border-red-300'
+    },
   };
 
   const verdictIcons = {
     verified: CheckCircle,
+    partially_true: AlertTriangle,
     misleading: AlertTriangle,
     false: XCircle,
     unverified: HelpCircle,
     satire: HelpCircle,
+    outdated: HelpCircle,
+    exaggerated: AlertTriangle,
+    opinion: HelpCircle,
+    rumor: HelpCircle,
+    conspiracy: XCircle,
+    debunked: XCircle,
   };
 
   const Icon = verdictIcons[data.verdict as keyof typeof verdictIcons] || HelpCircle;

--- a/components/analysis/origin-tracing-diagram/utils/navigationUtils.ts
+++ b/components/analysis/origin-tracing-diagram/utils/navigationUtils.ts
@@ -75,11 +75,22 @@ export function getVerdictColor(verdict: string): {
     case 'verified':
     case 'true':
       return getCredibilityColor(95);
+    case 'partially_true':
+      return getCredibilityColor(65);
     case 'misleading':
-    case 'satire':
+    case 'exaggerated':
       return getCredibilityColor(40);
+    case 'satire':
+      return getCredibilityColor(50);
     case 'false':
+    case 'conspiracy':
+    case 'debunked':
       return getCredibilityColor(10);
+    case 'outdated':
+    case 'rumor':
+      return getCredibilityColor(30);
+    case 'opinion':
+      return getCredibilityColor(70);
     case 'unverified':
     default:
       return getCredibilityColor(60);

--- a/components/hero/fact-check-display.tsx
+++ b/components/hero/fact-check-display.tsx
@@ -36,13 +36,20 @@ export function FactCheckDisplay({
   const [isDetailedAnalysisExpanded, setIsDetailedAnalysisExpanded] = useState(false);
 
   // Normalize various backend verdict strings to a canonical set used by UI
-  const normalizeVerdict = (status: string | undefined | null): "verified" | "false" | "misleading" | "unverified" | "satire" => {
+  const normalizeVerdict = (status: string | undefined | null): "verified" | "false" | "misleading" | "unverified" | "satire" | "partially_true" | "outdated" | "exaggerated" | "opinion" | "rumor" | "conspiracy" | "debunked" => {
     const value = (status || "").toString().trim().toLowerCase();
     if (value === "true" || value === "verified") return "verified";
     if (value === "false") return "false";
     if (value === "misleading") return "misleading";
     if (value === "unverified" || value === "unverifiable") return "unverified";
     if (value === "satire") return "satire";
+    if (value === "partially_true") return "partially_true";
+    if (value === "outdated") return "outdated";
+    if (value === "exaggerated") return "exaggerated";
+    if (value === "opinion") return "opinion";
+    if (value === "rumor") return "rumor";
+    if (value === "conspiracy") return "conspiracy";
+    if (value === "debunked") return "debunked";
     return "unverified";
   };
 
@@ -59,6 +66,20 @@ export function FactCheckDisplay({
         return <AlertCircleIcon className="h-4 w-4 text-gray-500" />;
       case "satire":
         return <span className="text-purple-500 text-sm">🎭</span>;
+      case "partially_true":
+        return <AlertTriangleIcon className="h-4 w-4 text-yellow-600" />;
+      case "outdated":
+        return <AlertCircleIcon className="h-4 w-4 text-gray-600" />;
+      case "exaggerated":
+        return <AlertTriangleIcon className="h-4 w-4 text-orange-600" />;
+      case "opinion":
+        return <AlertCircleIcon className="h-4 w-4 text-blue-500" />;
+      case "rumor":
+        return <AlertCircleIcon className="h-4 w-4 text-gray-400" />;
+      case "conspiracy":
+        return <XCircleIcon className="h-4 w-4 text-red-500" />;
+      case "debunked":
+        return <XCircleIcon className="h-4 w-4 text-red-700" />;
       default:
         return <AlertCircleIcon className="h-4 w-4 text-blue-500" />;
     }
@@ -100,6 +121,55 @@ export function FactCheckDisplay({
           <Badge className="bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-200 border border-purple-300 dark:border-purple-700">
             <SmileIcon className="h-3 w-3 mr-1" />
             Satirical Content
+          </Badge>
+        );
+      case "partially_true":
+        return (
+          <Badge className="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200 border border-yellow-300 dark:border-yellow-700">
+            <AlertTriangleIcon className="h-3 w-3 mr-1" />
+            Partially True
+          </Badge>
+        );
+      case "outdated":
+        return (
+          <Badge className="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border border-gray-300 dark:border-gray-600">
+            <AlertCircleIcon className="h-3 w-3 mr-1" />
+            Outdated Information
+          </Badge>
+        );
+      case "exaggerated":
+        return (
+          <Badge className="bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200 border border-orange-300 dark:border-orange-700">
+            <AlertTriangleIcon className="h-3 w-3 mr-1" />
+            Exaggerated Claims
+          </Badge>
+        );
+      case "opinion":
+        return (
+          <Badge className="bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 border border-blue-300 dark:border-blue-700">
+            <AlertCircleIcon className="h-3 w-3 mr-1" />
+            Opinion
+          </Badge>
+        );
+      case "rumor":
+        return (
+          <Badge className="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 border border-gray-300 dark:border-gray-600">
+            <AlertCircleIcon className="h-3 w-3 mr-1" />
+            Rumor
+          </Badge>
+        );
+      case "conspiracy":
+        return (
+          <Badge className="bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 border border-red-300 dark:border-red-700">
+            <XCircleIcon className="h-3 w-3 mr-1" />
+            Conspiracy Theory
+          </Badge>
+        );
+      case "debunked":
+        return (
+          <Badge className="bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 border border-red-300 dark:border-red-700">
+            <XCircleIcon className="h-3 w-3 mr-1" />
+            Debunked
           </Badge>
         );
       default:
@@ -198,6 +268,55 @@ export function FactCheckDisplay({
           description:
             analysisDescription ||
             "This content appears to be satirical, parody, or comedy in nature. It should not be interpreted as factual information.",
+        };
+      case "partially_true":
+        return {
+          title: "Partially True",
+          description:
+            analysisDescription ||
+            "This content contains both accurate and inaccurate elements. Some claims are supported by evidence while others are not.",
+        };
+      case "outdated":
+        return {
+          title: "Outdated Information",
+          description:
+            analysisDescription ||
+            "This information was accurate at one time but has been superseded by newer evidence or developments.",
+        };
+      case "exaggerated":
+        return {
+          title: "Exaggerated Claims",
+          description:
+            analysisDescription ||
+            "While based on some truth, this content overstates or sensationalizes the facts beyond what evidence supports.",
+        };
+      case "opinion":
+        return {
+          title: "Opinion",
+          description:
+            analysisDescription ||
+            "This content expresses subjective views or personal beliefs rather than factual claims that can be verified.",
+        };
+      case "rumor":
+        return {
+          title: "Rumor",
+          description:
+            analysisDescription ||
+            "This appears to be unverified information circulating without credible sources or confirmation.",
+        };
+      case "conspiracy":
+        return {
+          title: "Conspiracy Theory",
+          description:
+            analysisDescription ||
+            "This content involves claims about secret plots or hidden agendas without credible evidence to support them.",
+        };
+      case "debunked":
+        return {
+          title: "Debunked",
+          description:
+            analysisDescription ||
+            "This claim has been thoroughly disproven by multiple credible sources and scientific evidence.",
         };
       default:
         return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^1.0.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.901.0",
+        "@aws-sdk/client-comprehend": "^3.901.0",
         "@aws-sdk/client-dynamodb": "^3.670.0",
         "@aws-sdk/client-s3": "^3.670.0",
         "@aws-sdk/client-transcribe": "^3.670.0",
+        "@aws-sdk/client-translate": "^3.901.0",
         "@aws-sdk/credential-providers": "^3.901.0",
         "@aws-sdk/lib-dynamodb": "^3.670.0",
         "@hookform/resolvers": "^5.1.1",
@@ -1488,6 +1490,494 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-comprehend": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-comprehend/-/client-comprehend-3.901.0.tgz",
+      "integrity": "sha512-r7sRb0nYfoWHDY0V3chumRNpkvxurLgqhExBtpMLGY0W7bacQXRGNV37Bb8Yad6q45+QXNIk8rh1jilpfpDjQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/credential-provider-node": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/client-sso": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.901.0.tgz",
+      "integrity": "sha512-sGyDjjkJ7ppaE+bAKL/Q5IvVCxtoyBIzN+7+hWTS/mUxWJ9EOq9238IqmVIIK6sYNIzEf9yhobfMARasPYVTNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/core": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.901.0.tgz",
+      "integrity": "sha512-brKAc3y64tdhyuEf+OPIUln86bRTqkLgb9xkd6kUdIeA5+qmp/N6amItQz+RN4k4O3kqkCPYnAd3LonTKluobw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/xml-builder": "3.901.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/signature-v4": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.901.0.tgz",
+      "integrity": "sha512-5hAdVl3tBuARh3zX5MLJ1P/d+Kr5kXtDU3xm1pxUEF4xt2XkEEpwiX5fbkNkz2rbh3BCt2gOHsAbh6b3M7n+DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.901.0.tgz",
+      "integrity": "sha512-Ggr7+0M6QZEsrqRkK7iyJLf4LkIAacAxHz9c4dm9hnDdU7vqrlJm6g73IxMJXWN1bIV7IxfpzB11DsRrB/oNjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-stream": "^4.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.901.0.tgz",
+      "integrity": "sha512-zxadcDS0hNJgv8n4hFYJNOXyfjaNE1vvqIiF/JzZSQpSSYXzCd+WxXef5bQh+W3giDtRUmkvP5JLbamEFjZKyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/credential-provider-env": "3.901.0",
+        "@aws-sdk/credential-provider-http": "3.901.0",
+        "@aws-sdk/credential-provider-process": "3.901.0",
+        "@aws-sdk/credential-provider-sso": "3.901.0",
+        "@aws-sdk/credential-provider-web-identity": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.901.0.tgz",
+      "integrity": "sha512-dPuFzMF7L1s/lQyT3wDxqLe82PyTH+5o1jdfseTEln64LJMl0ZMWaKX/C1UFNDxaTd35Cgt1bDbjjAWHMiKSFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.901.0",
+        "@aws-sdk/credential-provider-http": "3.901.0",
+        "@aws-sdk/credential-provider-ini": "3.901.0",
+        "@aws-sdk/credential-provider-process": "3.901.0",
+        "@aws-sdk/credential-provider-sso": "3.901.0",
+        "@aws-sdk/credential-provider-web-identity": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.901.0.tgz",
+      "integrity": "sha512-/IWgmgM3Cl1wTdJA5HqKMAojxLkYchh5kDuphApxKhupLu6Pu0JBOHU8A5GGeFvOycyaVwosod6zDduINZxe+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.901.0.tgz",
+      "integrity": "sha512-SjmqZQHmqFSET7+6xcZgtH7yEyh5q53LN87GqwYlJZ6KJ5oNw11acUNEhUOL1xTSJEvaWqwTIkS2zqrzLcM9bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.901.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/token-providers": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.901.0.tgz",
+      "integrity": "sha512-NYjy/6NLxH9m01+pfpB4ql8QgAorJcu8tw69kzHwUd/ql6wUDTbC7HcXqtKlIwWjzjgj2BKL7j6SyFapgCuafA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.901.0.tgz",
+      "integrity": "sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.901.0.tgz",
+      "integrity": "sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.901.0.tgz",
+      "integrity": "sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.901.0.tgz",
+      "integrity": "sha512-Zby4F03fvD9xAgXGPywyk4bC1jCbnyubMEYChLYohD+x20ULQCf+AimF/Btn7YL+hBpzh1+RmqmvZcx+RgwgNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.901.0.tgz",
+      "integrity": "sha512-feAAAMsVwctk2Tms40ONybvpfJPLCmSdI+G+OTrNpizkGLNl6ik2Ng2RzxY6UqOfN8abqKP/DOUj1qYDRDG8ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz",
+      "integrity": "sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/token-providers": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.901.0.tgz",
+      "integrity": "sha512-pJEr1Ggbc/uVTDqp9IbNu9hdr0eQf3yZix3s4Nnyvmg4xmJSGAlbPC9LrNr5u3CDZoc8Z9CuLrvbP4MwYquNpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/types": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.901.0.tgz",
+      "integrity": "sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.901.0.tgz",
+      "integrity": "sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.901.0.tgz",
+      "integrity": "sha512-Ntb6V/WFI21Ed4PDgL/8NSfoZQQf9xzrwNgiwvnxgAl/KvAvRBgQtqj5gHsDX8Nj2YmJuVoHfH9BGjL9VQ4WNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.901.0.tgz",
+      "integrity": "sha512-l59KQP5TY7vPVUfEURc7P5BJKuNg1RSsAKBQW7LHLECXjLqDUbo2SMLrexLBEoArSt6E8QOrIN0C8z/0Xk0jYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.901.0.tgz",
+      "integrity": "sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.893.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.893.0.tgz",
@@ -1730,6 +2220,494 @@
         "@smithy/util-middleware": "^4.1.1",
         "@smithy/util-retry": "^4.1.2",
         "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-translate/-/client-translate-3.901.0.tgz",
+      "integrity": "sha512-KucMnO6PVz+Qh53s/KusK0JhPEM1rMdWDLox8/I3mlfHc0lE4rMAcbGWPNl/nbUe/OpzdHf/PLVwOvS0JW/FiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/credential-provider-node": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/client-sso": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.901.0.tgz",
+      "integrity": "sha512-sGyDjjkJ7ppaE+bAKL/Q5IvVCxtoyBIzN+7+hWTS/mUxWJ9EOq9238IqmVIIK6sYNIzEf9yhobfMARasPYVTNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/core": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.901.0.tgz",
+      "integrity": "sha512-brKAc3y64tdhyuEf+OPIUln86bRTqkLgb9xkd6kUdIeA5+qmp/N6amItQz+RN4k4O3kqkCPYnAd3LonTKluobw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/xml-builder": "3.901.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/signature-v4": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.901.0.tgz",
+      "integrity": "sha512-5hAdVl3tBuARh3zX5MLJ1P/d+Kr5kXtDU3xm1pxUEF4xt2XkEEpwiX5fbkNkz2rbh3BCt2gOHsAbh6b3M7n+DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.901.0.tgz",
+      "integrity": "sha512-Ggr7+0M6QZEsrqRkK7iyJLf4LkIAacAxHz9c4dm9hnDdU7vqrlJm6g73IxMJXWN1bIV7IxfpzB11DsRrB/oNjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-stream": "^4.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.901.0.tgz",
+      "integrity": "sha512-zxadcDS0hNJgv8n4hFYJNOXyfjaNE1vvqIiF/JzZSQpSSYXzCd+WxXef5bQh+W3giDtRUmkvP5JLbamEFjZKyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/credential-provider-env": "3.901.0",
+        "@aws-sdk/credential-provider-http": "3.901.0",
+        "@aws-sdk/credential-provider-process": "3.901.0",
+        "@aws-sdk/credential-provider-sso": "3.901.0",
+        "@aws-sdk/credential-provider-web-identity": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.901.0.tgz",
+      "integrity": "sha512-dPuFzMF7L1s/lQyT3wDxqLe82PyTH+5o1jdfseTEln64LJMl0ZMWaKX/C1UFNDxaTd35Cgt1bDbjjAWHMiKSFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.901.0",
+        "@aws-sdk/credential-provider-http": "3.901.0",
+        "@aws-sdk/credential-provider-ini": "3.901.0",
+        "@aws-sdk/credential-provider-process": "3.901.0",
+        "@aws-sdk/credential-provider-sso": "3.901.0",
+        "@aws-sdk/credential-provider-web-identity": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.901.0.tgz",
+      "integrity": "sha512-/IWgmgM3Cl1wTdJA5HqKMAojxLkYchh5kDuphApxKhupLu6Pu0JBOHU8A5GGeFvOycyaVwosod6zDduINZxe+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.901.0.tgz",
+      "integrity": "sha512-SjmqZQHmqFSET7+6xcZgtH7yEyh5q53LN87GqwYlJZ6KJ5oNw11acUNEhUOL1xTSJEvaWqwTIkS2zqrzLcM9bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.901.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/token-providers": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.901.0.tgz",
+      "integrity": "sha512-NYjy/6NLxH9m01+pfpB4ql8QgAorJcu8tw69kzHwUd/ql6wUDTbC7HcXqtKlIwWjzjgj2BKL7j6SyFapgCuafA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.901.0.tgz",
+      "integrity": "sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.901.0.tgz",
+      "integrity": "sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.901.0.tgz",
+      "integrity": "sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.901.0.tgz",
+      "integrity": "sha512-Zby4F03fvD9xAgXGPywyk4bC1jCbnyubMEYChLYohD+x20ULQCf+AimF/Btn7YL+hBpzh1+RmqmvZcx+RgwgNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.901.0.tgz",
+      "integrity": "sha512-feAAAMsVwctk2Tms40ONybvpfJPLCmSdI+G+OTrNpizkGLNl6ik2Ng2RzxY6UqOfN8abqKP/DOUj1qYDRDG8ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz",
+      "integrity": "sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/token-providers": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.901.0.tgz",
+      "integrity": "sha512-pJEr1Ggbc/uVTDqp9IbNu9hdr0eQf3yZix3s4Nnyvmg4xmJSGAlbPC9LrNr5u3CDZoc8Z9CuLrvbP4MwYquNpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/types": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.901.0.tgz",
+      "integrity": "sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.901.0.tgz",
+      "integrity": "sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.901.0.tgz",
+      "integrity": "sha512-Ntb6V/WFI21Ed4PDgL/8NSfoZQQf9xzrwNgiwvnxgAl/KvAvRBgQtqj5gHsDX8Nj2YmJuVoHfH9BGjL9VQ4WNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.901.0.tgz",
+      "integrity": "sha512-l59KQP5TY7vPVUfEURc7P5BJKuNg1RSsAKBQW7LHLECXjLqDUbo2SMLrexLBEoArSt6E8QOrIN0C8z/0Xk0jYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.901.0.tgz",
+      "integrity": "sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^1.0.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.901.0",
+    "@aws-sdk/client-comprehend": "^3.901.0",
     "@aws-sdk/client-dynamodb": "^3.670.0",
     "@aws-sdk/client-s3": "^3.670.0",
     "@aws-sdk/client-transcribe": "^3.670.0",
+    "@aws-sdk/client-translate": "^3.901.0",
     "@aws-sdk/credential-providers": "^3.901.0",
     "@aws-sdk/lib-dynamodb": "^3.670.0",
     "@hookform/resolvers": "^5.1.1",

--- a/tools/content-analysis/tools/credibility-rating.ts
+++ b/tools/content-analysis/tools/credibility-rating.ts
@@ -46,10 +46,33 @@ export const calculateCreatorCredibilityRating = tool({
               credibilityScore += 3.0;
               factors.push("Content verified as true (+3.0)");
               break;
+            case "partially_true":
+              credibilityScore += 1.0;
+              factors.push("Content partially true (+1.0)");
+              break;
             case "false":
-            case "misleading":
+            case "conspiracy":
+            case "debunked":
               credibilityScore -= 4.0;
-              factors.push("Content flagged as false/misleading (-4.0)");
+              factors.push("Content flagged as false/conspiracy/debunked (-4.0)");
+              break;
+            case "misleading":
+            case "exaggerated":
+              credibilityScore -= 3.0;
+              factors.push("Content flagged as misleading/exaggerated (-3.0)");
+              break;
+            case "outdated":
+            case "rumor":
+              credibilityScore -= 2.0;
+              factors.push("Content flagged as outdated/rumor (-2.0)");
+              break;
+            case "opinion":
+              credibilityScore += 0.5;
+              factors.push("Content identified as opinion (+0.5)");
+              break;
+            case "satire":
+              credibilityScore += 1.0;
+              factors.push("Content identified as satire (+1.0)");
               break;
             case "unverifiable":
               credibilityScore -= 1.0;

--- a/tools/fact-checking/verification-analysis.ts
+++ b/tools/fact-checking/verification-analysis.ts
@@ -53,8 +53,35 @@ export async function analyzeVerificationStatus(
     ) {
       status = "verified";
       confidence = 0.7;
+    } else if (lowercaseContent.includes("partially true") || lowercaseContent.includes("partially correct")) {
+      status = "partially_true";
+      confidence = 0.7;
     } else if (lowercaseContent.includes("misleading")) {
       status = "misleading";
+      confidence = 0.7;
+    } else if (lowercaseContent.includes("false") || lowercaseContent.includes("incorrect") || lowercaseContent.includes("wrong")) {
+      status = "false";
+      confidence = 0.7;
+    } else if (lowercaseContent.includes("exaggerated") || lowercaseContent.includes("overstated")) {
+      status = "exaggerated";
+      confidence = 0.7;
+    } else if (lowercaseContent.includes("outdated") || lowercaseContent.includes("superseded")) {
+      status = "outdated";
+      confidence = 0.7;
+    } else if (lowercaseContent.includes("opinion") || lowercaseContent.includes("subjective")) {
+      status = "opinion";
+      confidence = 0.7;
+    } else if (lowercaseContent.includes("rumor") || lowercaseContent.includes("unverified")) {
+      status = "rumor";
+      confidence = 0.7;
+    } else if (lowercaseContent.includes("conspiracy") || lowercaseContent.includes("conspiracy theory")) {
+      status = "conspiracy";
+      confidence = 0.7;
+    } else if (lowercaseContent.includes("debunked") || lowercaseContent.includes("disproven")) {
+      status = "debunked";
+      confidence = 0.8;
+    } else if (lowercaseContent.includes("satire") || lowercaseContent.includes("parody") || lowercaseContent.includes("humor")) {
+      status = "satire";
       confidence = 0.7;
     } else if (lowercaseContent.includes("unverifiable")) {
       status = "unverifiable";
@@ -76,7 +103,7 @@ Research Results:
 ${searchContent}
 
 Based on the research evidence, determine:
-1. Verification Status: Choose ONE of: "verified", "misleading", "unverifiable"
+1. Verification Status: Choose ONE of: "verified", "partially_true", "misleading", "false", "exaggerated", "outdated", "opinion", "rumor", "conspiracy", "debunked", "satire", "unverifiable"
 2. Confidence Level: A number from 0.0 to 1.0 representing how confident you are in this assessment
 
 Guidelines:
@@ -84,10 +111,46 @@ Guidelines:
   * Use this even if minor secondary details (like superlatives "first ever", "only one") are inaccurate
   * Focus on whether the main factual assertion is true
   * Example: "Australia offers free education" (verified) vs "first country to do so" (secondary detail)
+
+- "partially_true": The claim contains both accurate and inaccurate elements
+  * Use when some facts are correct but others are wrong or misleading
+  * Example: "The vaccine causes autism" (partially true - vaccine exists, but autism claim is false)
   
 - "misleading": The PRIMARY claim itself is substantially false, lacks critical context, or is deceptive
   * Use this when the core fact is wrong or presented in a way that creates false impressions
   * Do NOT use this just because embellishments or secondary details are inaccurate
+
+- "false": The claim is demonstrably incorrect based on credible evidence
+  * Use for clearly debunked claims with strong evidence against them
+  * Example: "COVID-19 was created in a lab" (false - natural origin confirmed by scientists)
+
+- "exaggerated": The claim contains truth but is overstated or sensationalized
+  * Use when facts are stretched beyond what evidence supports
+  * Example: "Millions died from vaccines" (exaggerated - some deaths occurred but not millions)
+
+- "outdated": The claim was true at one time but is no longer accurate
+  * Use for information that has been superseded by newer evidence
+  * Example: "The Earth is flat" (outdated - disproven centuries ago)
+
+- "opinion": The content expresses subjective views rather than factual claims
+  * Use for personal beliefs, preferences, or subjective statements
+  * Example: "This movie is terrible" (opinion - not a factual claim)
+
+- "rumor": Unverified information circulating without credible sources
+  * Use for unsubstantiated claims that lack reliable evidence
+  * Example: "Celebrity X is getting divorced" (rumor - no confirmed sources)
+
+- "conspiracy": Claims involving secret plots or hidden agendas without evidence
+  * Use for theories about secretive groups controlling events
+  * Example: "The government is hiding aliens" (conspiracy - no credible evidence)
+
+- "debunked": Claims that have been thoroughly disproven by multiple sources
+  * Use for claims with strong evidence against them from credible sources
+  * Example: "Vaccines cause autism" (debunked - multiple studies disprove this)
+
+- "satire": Content intended as humor or parody, not factual information
+  * Use for comedic content that might be mistaken for real news
+  * Example: "Man bites dog" from satirical news site (satire)
   
 - "unverifiable": Insufficient credible evidence to make a determination about the primary claim
 

--- a/types/analysis.ts
+++ b/types/analysis.ts
@@ -1,5 +1,5 @@
 export interface FactCheckResult {
-  verdict: "verified" | "misleading" | "false" | "unverified" | "satire";
+  verdict: "verified" | "misleading" | "false" | "unverified" | "satire" | "partially_true" | "outdated" | "exaggerated" | "opinion" | "rumor" | "conspiracy" | "debunked";
   confidence: number;
   explanation: string;
   content: string;


### PR DESCRIPTION
- Add 7 new verdict categories: partially_true, outdated, exaggerated, opinion, rumor, conspiracy, debunked
- Update AI prompt with detailed guidelines for each category
- Enhance fallback keyword-based analysis for new categories
- Update all UI components with appropriate icons, colors, and descriptions
- Improve credibility rating calculation for new verdicts
- Fix issue where fake news was incorrectly classified as 'unverifiable'
- Add comprehensive color coding system for better visual distinction

This addresses the core issue where clearly false claims like 'COVID was made in a lab' were being marked as 'unverifiable' instead of 'false' or 'debunked'.